### PR TITLE
Add key property

### DIFF
--- a/Runtime/Console.cs
+++ b/Runtime/Console.cs
@@ -123,7 +123,7 @@ public class Console : MonoBehaviour
     private string input;
     private float deltaTime;
     private bool open;
-    private KeyCode key;
+    private KeyCode key = KeyCode.Tilde;
     private int scroll;
     private int index;
     private int lastMaxLines;

--- a/Runtime/Console.cs
+++ b/Runtime/Console.cs
@@ -86,6 +86,18 @@ public class Console : MonoBehaviour
         }
     }
 
+    public static KeyCode Key
+    {
+        get
+        {
+            return Instance.key;
+        }
+        set
+        {
+            Instance.key = value;
+        }
+    }
+
     private static int Scroll
     {
         get
@@ -111,6 +123,7 @@ public class Console : MonoBehaviour
     private string input;
     private float deltaTime;
     private bool open;
+    private KeyCode key;
     private int scroll;
     private int index;
     private int lastMaxLines;
@@ -490,13 +503,9 @@ public class Console : MonoBehaviour
         }
     }
 
-    private bool IsConsoleKey(KeyCode key)
+    private bool IsConsoleKey(KeyCode keyCode)
     {
-        if (key == KeyCode.BackQuote)
-        {
-            return true;
-        }
-        else if (key == KeyCode.Tilde)
+        if (keyCode == key)
         {
             return true;
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.popcron.console",
     "displayName": "Popcron Console",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "unity": "2018.3",
     "description": "Command parsing API."
 }


### PR DESCRIPTION
I have added the Console.Key property that is mentiont in the readme. I have also set the default value to the old hardcode value, so there shouldn't be any problmes for those who don't want to assing a custom Key to open the console.